### PR TITLE
Fix mute/unmute user on readonly room

### DIFF
--- a/apps/meteor/client/views/room/hooks/useUserInfoActions/actions/useMuteUserAction.tsx
+++ b/apps/meteor/client/views/room/hooks/useUserInfoActions/actions/useMuteUserAction.tsx
@@ -27,8 +27,8 @@ const getUserIsMuted = (
 			return false;
 		}
 
-		if (userCanPostReadonly) {
-			return Array.isArray(room.muted) && room.muted.indexOf(user.username ?? '') !== -1;
+		if (userCanPostReadonly && Array.isArray(room.muted) && room.muted.indexOf(user.username ?? '') !== -1) {
+			return true;
 		}
 
 		return true;


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  [NEW] For new features
  [IMPROVE] For an improvement (performance or little improvements) in existing features
  [FIX] For bug fixes that affect the end-user
  [BREAK] For pull requests including breaking changes
  Chore: For small tasks
  Doc: For documentation
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. 
  - I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
  - I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
  - Lint and unit tests pass locally with my changes
  - I have added tests that prove my fix is effective or that my feature works (if applicable)
  - I have added necessary documentation (if applicable)
  - Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes (including videos or screenshots)
<!-- CHANGELOG -->
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description will appear in the release notes if we accept the contribution.
-->
On readonly room the user action menu always show `mute user` even that all users are mute 
this issue caused by room.muted and room.unmuted undefined (getUserIsMuted always false) 
the work-around is to mute the user (even if he is already mute) then unmute him, so `room.muted and room.unmuted` will be defined 
The fix is :
1. if room.unmuted exist and user is on it: getUserIsMuted = false -> show `mute user` 
2. if room.mute exist and user is on it: getUserIsMuted = true -> show `unmute user`
<!-- END CHANGELOG -->

## Issue(s)
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->

## Steps to test or reproduce
<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->
1. Create new room
2. add a user to it
3. set the room readonly
4. room members action menu does not show `unmute user` 
## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
